### PR TITLE
Update solarized-dark to improve drawn spaces contrast

### DIFF
--- a/debian/patches/fix-solarized-dark-draw-spaces.patch
+++ b/debian/patches/fix-solarized-dark-draw-spaces.patch
@@ -10,7 +10,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
    <color name="base1"   value="#93A1A1"/>
    <color name="base2"   value="#EEE8D5"/>
    <color name="base3"   value="#FDF6E3"/>
-+  <color name="base4"   value="#33535D"/>
++  <color name="base4"   value="#436069"/>
    <color name="yellow"  value="#B58900"/>
    <color name="orange"  value="#CB4B16"/>
    <color name="red"     value="#DC322F"/>

--- a/debian/patches/fix-solarized-dark-draw-spaces.patch
+++ b/debian/patches/fix-solarized-dark-draw-spaces.patch
@@ -1,0 +1,24 @@
+Description: Slightly modify solarized-dark color scheme for better visibility
+ Make the color used for drawn spaces contrast slightly better against the background
+ of both selected and unselected text
+Author: David Hewitt <davidmhewitt@gmail.com>
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/data/styles/solarized-dark.xml
++++ b/data/styles/solarized-dark.xml
+@@ -34,6 +34,7 @@
+   <color name="base1"   value="#93A1A1"/>
+   <color name="base2"   value="#EEE8D5"/>
+   <color name="base3"   value="#FDF6E3"/>
++  <color name="base4"   value="#33535D"/>
+   <color name="yellow"  value="#B58900"/>
+   <color name="orange"  value="#CB4B16"/>
+   <color name="red"     value="#DC322F"/>
+@@ -53,6 +54,7 @@
+   <style name="current-line"                background="base02"/>
+   <style name="line-numbers"                foreground="base01" background="base02"/>
+   <style name="background-pattern"          background="base03-02-blend"/>
++  <style name="draw-spaces"                 foreground="base4"/>
+ 
+   <!-- Bracket Matching -->
+   <style name="bracket-match"               foreground="base03" background="base01"/>

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+fix-solarized-dark-draw-spaces.patch


### PR DESCRIPTION
A very subtle change, but hopefully makes the contrast _just about_ good enough to actually be able to see the dots when the text is selected. The selected background and unselected background are unfortunately too contrasting to find a really good color for this, and we can't have a different color for each.

We also don't want to end up making the dots stand out too much by making them really white or else it starts to look like part of the code.

Before:
![screenshot from 2018-06-15 19 04 55](https://user-images.githubusercontent.com/3372394/41482916-05e2e6a2-70cf-11e8-84b4-e107b896a1c3.png)

After:
![screenshot from 2018-06-15 19 17 52](https://user-images.githubusercontent.com/3372394/41483389-d9fc817c-70d0-11e8-9164-78b8ed362037.png)

