### PR TITLE
Allow specifying a different upstream series for backports

### DIFF
--- a/.github/workflows/juno.yml
+++ b/.github/workflows/juno.yml
@@ -32,7 +32,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_REPOSITORY: elementary/os-patches
       run: |
-        while read -r line; do
+        while IFS=":" read -r line upstream_series; do
             echo "Checking version for $line"
-            python3 ./get-latest-version.py "$line" "bionic"
+            python3 ./get-latest-version.py "$line" "bionic" "$upstream_series"
         done < "/tmp/patched-packages"

--- a/README.md
+++ b/README.md
@@ -8,13 +8,17 @@ The packages are included into the [OS Patches Repository](https://launchpad.net
 
 The `master` branch is composed of GitHub Workflows that are running daily to
 check for any new version in the Ubuntu repositories of the patched components.
-It uses the `get-latest-version.py` python script included.
+If a newer version of a package is found in the Ubuntu repositories, a GitHub issue
+will be opened in this repository to let the team know to rebase patches and push
+and update.
+
+The workflow uses the `get-latest-version.py` python script included.
 
 It depends on `python3-launchpadlib`, `python3-apt` and `python3-github`.
 
 ## Many branches
 
-The repository is made of several distinc branches:
+The repository is made of several distinct branches:
  * `import-list-$UBUNTU_NAME` is the branch listing the different packages
  that are getting patched.
  * `$PACKAGE-$UBUNTU_NAME` is the last source that got used to create the
@@ -22,6 +26,12 @@ The repository is made of several distinc branches:
  * `$PACKAGE-$UBUNTU_NAME-patched` is `$PACKAGE-$UBUNTU_NAME` with the patch
  applied on it
 
+The package list file in `import-list-$UBUNTU_NAME` contains one package per
+line of packages to be monitored by the workflow. If the patched package has
+been backported from a newer Ubuntu release, you can denote this in the list
+with a colon separator
+
+e.g. `packagekit:$NEWER_UBUNTU_NAME`
 
 > Note that when possible, we try to discourage the use of OS patches and work
 directly with upstream to include them.

--- a/get-latest-version.py
+++ b/get-latest-version.py
@@ -11,9 +11,14 @@ if len(sys.argv) < 2:
     raise ValueError("Please provide a package name")
 
 if len(sys.argv) < 3:
-    serie_name = "bionic"
+    series_name = "bionic"
 else:
-    serie_name = sys.argv[2]
+    series_name = sys.argv[2]
+
+if len(sys.argv) < 4:
+    upstream_series_name = series_name
+else:
+    upstream_series_name = sys.argv[3]
 
 component_name = sys.argv[1]
 
@@ -31,7 +36,8 @@ launchpad = Launchpad.login_anonymously(
 ubuntu = launchpad.distributions["ubuntu"]
 ubuntu_archive = ubuntu.main_archive
 patches_archive = launchpad.people['elementary-os'].getPPAByName(distribution=ubuntu,name='os-patches')
-series = ubuntu.getSeries(name_or_version=serie_name)
+series = ubuntu.getSeries(name_or_version=series_name)
+upstream_series = ubuntu.getSeries(name_or_version=upstream_series_name)
 
 # Initialize GitHub variables
 github_token = os.environ['GITHUB_TOKEN']
@@ -55,7 +61,7 @@ for pocket in pockets:
         source_name=component_name,
         status="Published",
         pocket=pocket,
-        distro_series=series)
+        distro_series=upstream_series)
     if len(found_sources) > 0:
         pocket_version = found_sources[0].source_package_version
         if apt_pkg.version_compare(pocket_version, patched_version) > 0:


### PR DESCRIPTION
When we backport newer versions of packages, we usually take them from newer ubuntu releases.

In this case, our version will always be newer than the version in the current ubuntu series, so we won't get issue notifications when a new version gets published upstream.

This PR adds an extra argument to the python script to allow specifying the upstream series and in the package list, we can do something like:
`packagekit:disco`

Any lines without a colon are just assumed to be in the current series.