### PR TITLE
Add backported PackageKit 1.1.12

### DIFF
--- a/bionic/packages_to_import
+++ b/bionic/packages_to_import
@@ -17,6 +17,7 @@ live-build
 lsb
 mutter
 network-manager-applet
+packagekit:disco
 python-apt
 software-properties
 system-config-printer


### PR DESCRIPTION
This syntax requires #70

I've created the necessary branches and tested the build locally in a pbuilder environment. I assume someone needs to set something up in launchpad to build this first though?