### PR TITLE
fix an extra quote in apps security updates

### DIFF
--- a/data/50unattended-upgrades.Ubuntu
+++ b/data/50unattended-upgrades.Ubuntu
@@ -10,7 +10,7 @@ Unattended-Upgrade::Allowed-Origins {
 	// every release and this system may not have it installed, but if
 	// available, the policy for updates is such that unattended-upgrades
 	// should also install from here by default.
-	"UbuntuESMApps:bionic-apps-security"";
+	"UbuntuESMApps:bionic-apps-security";
 	"UbuntuESM:bionic-infra-security";
 //	"Ubuntu:bionic-updates";
 //	"Ubuntu:bionic-proposed";
@@ -30,7 +30,7 @@ Unattended-Upgrade::Package-Blacklist {
 Unattended-Upgrade::DevRelease "false";
 
 // This option allows you to control if on a unclean dpkg exit
-// unattended-upgrades will automatically run 
+// unattended-upgrades will automatically run
 //   dpkg --force-confold --configure -a
 // The default is true, to ensure updates keep getting installed
 //Unattended-Upgrade::AutoFixInterruptedDpkg "false";
@@ -65,7 +65,7 @@ Unattended-Upgrade::DevRelease "false";
 //Unattended-Upgrade::Remove-Unused-Dependencies "false";
 
 // Automatically reboot *WITHOUT CONFIRMATION*
-//  if the file /var/run/reboot-required is found after the upgrade 
+//  if the file /var/run/reboot-required is found after the upgrade
 //Unattended-Upgrade::Automatic-Reboot "false";
 
 // If automatic reboot is enabled and needed, reboot at the specific


### PR DESCRIPTION
This should resolve the following error when running `dist-upgrade`:

```bash
E: Syntax error /etc/apt/apt.conf.d/50unattended-upgrades:14: Malformed tag
```

Related issues/pipelines:

https://elementaryos.stackexchange.com/questions/22584/update-for-unattended-updates-causes-problems

https://github.com/elementary/docker/pull/14/checks?check_run_id=500895498