### PR TITLE
Conf: Revert to upstream geoclue API key

### DIFF
--- a/data/geoclue.conf.in
+++ b/data/geoclue.conf.in
@@ -18,7 +18,7 @@ enable=true
 
 # URL to the wifi geolocation service. The key can currenty be anything, just
 # needs to be present but that is likely going to change in future.
-url=https://location.services.mozilla.com/v1/geolocate?key=99054b086f8a4b9fa033e4a75801ab52
+url=https://location.services.mozilla.com/v1/geolocate?key=geoclue
 
 # To use the Google geolocation service instead of mozilla's, simply uncomment
 # this url while changing API_KEY to your Google API key and comment out or


### PR DESCRIPTION
Our key is expired and Mozilla hasn't given us a new one