### PR TITLE
focal: Add gtksourceview4

### DIFF
--- a/focal/packages_to_import
+++ b/focal/packages_to_import
@@ -1,2 +1,3 @@
 base-files
+gtksourceview4
 lsb


### PR DESCRIPTION
Fixes #115 

I've created the necessary branches, we just need the launchpad recipe setting up.

The only patch I've added for the time being is to fix the draw-spaces contrast in the solarized themes. In `bionic` we had a bunch of other patches to add more language specs. We can add those later if necessary/still desired.