### PR TITLE
plymouth: Change default fonts

### DIFF
--- a/debian/local/plymouth.hook
+++ b/debian/local/plymouth.hook
@@ -131,17 +131,17 @@ case "${THEME_NAME}" in
 		# Make Inter the default sans-serif font
 		if [ -e /usr/share/fonts/opentype/inter/Inter-Regular.otf ]
 		then
-		    sed -i 's|\(<family>DejaVu Sans</family>\)|<family>Inter</family>\1|;' "${DESTDIR}/etc/fonts/conf.d/60-latin.conf"
-		    mkdir -p "${DESTDIR}/usr/share/fonts/opentype/inter"
-		    cp -a /usr/share/fonts/opentype/inter/Inter-Regular.otf "${DESTDIR}/usr/share/fonts/opentype/inter"
+			sed -i 's|\(<family>DejaVu Sans</family>\)|<family>Inter</family>\1|;' "${DESTDIR}/etc/fonts/conf.d/60-latin.conf"
+			mkdir -p "${DESTDIR}/usr/share/fonts/opentype/inter"
+			cp -a /usr/share/fonts/opentype/inter/Inter-Regular.otf "${DESTDIR}/usr/share/fonts/opentype/inter"
 		fi
 
 		# Make Open sans the default mono font
 		if [ -e /usr/share/fonts/truetype/open-sans/OpenSans-Regular.ttf ]
 		then
-		    sed -i 's|\(<family>DejaVu Sans Mono</family>\)|<family>Open Sans</family>\1|;' "${DESTDIR}/etc/fonts/conf.d/60-latin.conf"
-		    mkdir -p "${DESTDIR}/usr/share/fonts/truetype/open-sans"
-		    cp -a /usr/share/fonts/truetype/open-sans/OpenSans-Regular.ttf "${DESTDIR}/usr/share/fonts/truetype/open-sans"
+			sed -i 's|\(<family>DejaVu Sans Mono</family>\)|<family>Open Sans</family>\1|;' "${DESTDIR}/etc/fonts/conf.d/60-latin.conf"
+			mkdir -p "${DESTDIR}/usr/share/fonts/truetype/open-sans"
+			cp -a /usr/share/fonts/truetype/open-sans/OpenSans-Regular.ttf "${DESTDIR}/usr/share/fonts/truetype/open-sans"
 		fi
 		fc-cache -s -y "${DESTDIR}" > /dev/null 2>&1
 

--- a/debian/local/plymouth.hook
+++ b/debian/local/plymouth.hook
@@ -143,6 +143,7 @@ case "${THEME_NAME}" in
 			mkdir -p "${DESTDIR}/usr/share/fonts/truetype/open-sans"
 			cp -a /usr/share/fonts/truetype/open-sans/OpenSans-Regular.ttf "${DESTDIR}/usr/share/fonts/truetype/open-sans"
 		fi
+
 		fc-cache -s -y "${DESTDIR}" > /dev/null 2>&1
 
 		# pango

--- a/debian/local/plymouth.hook
+++ b/debian/local/plymouth.hook
@@ -119,11 +119,6 @@ case "${THEME_NAME}" in
 		;;
 
 	*)
-		cp /usr/share/plymouth/ubuntu-logo.png "${DESTDIR}/usr/share/plymouth"
-		if [ -d ${DESTDIR}/usr/share/plymouth/themes/spinner ]; then
-			cp /usr/share/plymouth/ubuntu-logo.png "${DESTDIR}/usr/share/plymouth/themes/spinner/watermark.png"
-		fi
-
 		# fontconfig
 		mkdir -p "${DESTDIR}/etc/fonts/conf.d"
 		cp -a /etc/fonts/fonts.conf "${DESTDIR}/etc/fonts"

--- a/debian/local/plymouth.hook
+++ b/debian/local/plymouth.hook
@@ -136,12 +136,12 @@ case "${THEME_NAME}" in
 			cp -a /usr/share/fonts/opentype/inter/Inter-Regular.otf "${DESTDIR}/usr/share/fonts/opentype/inter"
 		fi
 
-		# Make Open sans the default mono font
-		if [ -e /usr/share/fonts/truetype/open-sans/OpenSans-Regular.ttf ]
+		# Make Roboto Mono the default mono font
+		if [ -e /usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-Regular.ttf ]
 		then
-			sed -i 's|\(<family>DejaVu Sans Mono</family>\)|<family>Open Sans</family>\1|;' "${DESTDIR}/etc/fonts/conf.d/60-latin.conf"
-			mkdir -p "${DESTDIR}/usr/share/fonts/truetype/open-sans"
-			cp -a /usr/share/fonts/truetype/open-sans/OpenSans-Regular.ttf "${DESTDIR}/usr/share/fonts/truetype/open-sans"
+			sed -i 's|\(<family>DejaVu Sans Mono</family>\)|<family>Roboto Mono</family>\1|;' "${DESTDIR}/etc/fonts/conf.d/60-latin.conf"
+			mkdir -p "${DESTDIR}/usr/share/fonts/truetype/roboto-mono-elementary"
+			cp -a /usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-Regular.ttf "${DESTDIR}/usr/share/fonts/truetype/roboto-mono-elementary"
 		fi
 
 		fc-cache -s -y "${DESTDIR}" > /dev/null 2>&1

--- a/debian/local/plymouth.hook
+++ b/debian/local/plymouth.hook
@@ -126,17 +126,22 @@ case "${THEME_NAME}" in
 		# This is only needed because fc-cache bellow fails if the directory doesn't exist
 		mkdir -p "${DESTDIR}/usr/local/share/fonts"
 
-		# Make Ubuntu the default sans-serif, and mono fonts.  Ubuntu
-		# font is always present if we have python-label installed; if
-		# not installed, then we have no graphical themes that display
-		# text, so that's ok.
-		if [ -e /usr/share/fonts/truetype/ubuntu/Ubuntu-R.ttf ]
+		cp /etc/fonts/conf.d/60-latin.conf "${DESTDIR}/etc/fonts/conf.d/60-latin.conf"
+
+		# Make Inter the default sans-serif font
+		if [ -e /usr/share/fonts/opentype/inter/Inter-Regular.otf ]
 		then
-		    sed 's|\(<family>DejaVu Sans</family>\)|<family>Ubuntu</family>\1|;s|\(<family>DejaVu Sans Mono</family>\)|<family>Ubuntu Mono</family>\1|;' \
-			/etc/fonts/conf.d/60-latin.conf > "${DESTDIR}/etc/fonts/conf.d/60-latin.conf"
-		    mkdir -p "${DESTDIR}/usr/share/fonts/truetype/ubuntu"
-		    cp -a /usr/share/fonts/truetype/ubuntu/Ubuntu-R.ttf "${DESTDIR}/usr/share/fonts/truetype/ubuntu"
-		    cp -a /usr/share/fonts/truetype/ubuntu/UbuntuMono-R.ttf "${DESTDIR}/usr/share/fonts/truetype/ubuntu"
+		    sed -i 's|\(<family>DejaVu Sans</family>\)|<family>Inter</family>\1|;' "${DESTDIR}/etc/fonts/conf.d/60-latin.conf"
+		    mkdir -p "${DESTDIR}/usr/share/fonts/opentype/inter"
+		    cp -a /usr/share/fonts/opentype/inter/Inter-Regular.otf "${DESTDIR}/usr/share/fonts/opentype/inter"
+		fi
+
+		# Make Open sans the default mono font
+		if [ -e /usr/share/fonts/truetype/open-sans/OpenSans-Regular.ttf ]
+		then
+		    sed -i 's|\(<family>DejaVu Sans Mono</family>\)|<family>Open Sans</family>\1|;' "${DESTDIR}/etc/fonts/conf.d/60-latin.conf"
+		    mkdir -p "${DESTDIR}/usr/share/fonts/truetype/open-sans"
+		    cp -a /usr/share/fonts/truetype/open-sans/OpenSans-Regular.ttf "${DESTDIR}/usr/share/fonts/truetype/open-sans"
 		fi
 		fc-cache -s -y "${DESTDIR}" > /dev/null 2>&1
 


### PR DESCRIPTION
Closes https://github.com/elementary/os-patches/issues/163

@cassidyjames and @hanaral could you please test this:

You have to open `/usr/share/initramfs-tools/hooks/plymouth`

```
sudo nano /usr/share/initramfs-tools/hooks/plymouth
```

go to line 134 and replace this

```
# Make Ubuntu the default sans-serif, and mono fonts.  Ubuntu
# font is always present if we have python-label installed; if
# not installed, then we have no graphical themes that display
# text, so that's ok.
if [ -e /usr/share/fonts/truetype/ubuntu/Ubuntu-R.ttf ]
then
    sed 's|\(<family>DejaVu Sans</family>\)|<family>Ubuntu</family>\1|;s|\(<family>DejaVu Sans Mono<>
        /etc/fonts/conf.d/60-latin.conf > "${DESTDIR}/etc/fonts/conf.d/60-latin.conf"
    mkdir -p "${DESTDIR}/usr/share/fonts/truetype/ubuntu"
    cp -a /usr/share/fonts/truetype/ubuntu/Ubuntu-R.ttf "${DESTDIR}/usr/share/fonts/truetype/ubuntu"
    cp -a /usr/share/fonts/truetype/ubuntu/UbuntuMono-R.ttf "${DESTDIR}/usr/share/fonts/truetype/ubu>
fi
```

with this

```
cp /etc/fonts/conf.d/60-latin.conf "${DESTDIR}/etc/fonts/conf.d/60-latin.conf"

# Make Inter the default sans-serif font
if [ -e /usr/share/fonts/opentype/inter/Inter-Regular.otf ]
then
    sed -i 's|\(<family>DejaVu Sans</family>\)|<family>Inter</family>\1|;' "${DESTDIR}/etc/fonts/conf.d/60-latin.conf"
    mkdir -p "${DESTDIR}/usr/share/fonts/opentype/inter"
    cp -a /usr/share/fonts/opentype/inter/Inter-Regular.otf "${DESTDIR}/usr/share/fonts/opentype/inter"
fi

# Make Roboto Mono the default mono font
if [ -e /usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-Regular.ttf ]
then
    sed -i 's|\(<family>DejaVu Sans Mono</family>\)|<family>Roboto Mono</family>\1|;' "${DESTDIR}/etc/fonts/conf.d/60-latin.conf"
    mkdir -p "${DESTDIR}/usr/share/fonts/truetype/roboto-mono-elementary"
    cp -a /usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-Regular.ttf "${DESTDIR}/usr/share/fonts/truetype/roboto-mono-elementary"
fi
```

After that you have to rebuild the **initramfs** with

```
sudo update-initramfs -u -k all
```

Now reboot to check if it worked.

Don't worry, you can reset your **plymouth** config with

```
sudo apt reinstall plymouth
```