### PR TITLE
Re-alias update-grub command to elementary path

### DIFF
--- a/debian/update-grub
+++ b/debian/update-grub
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -e
-exec grub-mkconfig -o /boot/grub/grub.cfg "$@"
+exec grub-mkconfig -o /boot/efi/EFI/ubuntu/grub/grub.cfg "$@"

--- a/debian/update-grub.8
+++ b/debian/update-grub.8
@@ -8,7 +8,7 @@ update-grub, update-grub2 \- stub for grub-mkconfig
 .SH DESCRIPTION
 .B update-grub
 is a stub for running
-.B grub-mkconfig -o /boot/grub/grub.cfg
+.B grub-mkconfig -o /boot/efi/EFI/ubuntu/grub/grub.cfg
 to generate a grub2 config file.
 .SH "SEE ALSO"
 .BR grub-mkconfig (8)


### PR DESCRIPTION
Fixes #178
Fixes #192 
Fixes #193 

This seems to be the cause of a common complaint about Odin where bootloader config doesn't get updated when installing new kernels etc.

Distinst installs GRUB so that its config is also contained on the `/boot/efi` partition, which differs from the Ubuntu default, so we can essentially re-alias the `update-grub` command to point to this location.

Distinst does that so that everything other than your ESP can be encrypted in theory, though we don't currently go that far.