### PR TITLE
Re-alias update-grub command to elementary path

### DIFF
--- a/debian/update-grub
+++ b/debian/update-grub
@@ -1,3 +1,7 @@
 #!/bin/sh
 set -e
-exec grub-mkconfig -o /boot/grub/grub.cfg "$@"
+grub-mkconfig -o /boot/grub/grub.cfg "$@"
+# If we have some GRUB config in the Ubuntu EFI folder, also update that
+if [ -d "/boot/efi/EFI/ubuntu/grub" ]; then
+  grub-mkconfig -o /boot/efi/EFI/ubuntu/grub/grub.cfg "$@"
+fi


### PR DESCRIPTION
Fixes #178
Fixes #192 
Fixes #193 

This seems to be the cause of a common complaint about Odin where bootloader config doesn't get updated when installing new kernels etc.

Distinst installs GRUB so that its config is also contained on the `/boot/efi` partition, which differs from the Ubuntu default, so we can essentially re-alias the `update-grub` command to update to this location too. There's no harm in updating both locations, as only one config file gets loaded anyway. So if someone has re-installed their GRUB to load config from the default Ubuntu location instead of the distinst location, this will continue to work. This also works for legacy BIOS systems as that will load from /boot/grub/grub.cfg.