### PR TITLE
Ensure recordfail state is cleared in our grubenv

### DIFF
--- a/debian/grub-common.init
+++ b/debian/grub-common.init
@@ -23,6 +23,9 @@ case $1 in
 	[ -s /boot/grub/grubenv ] || rm -f /boot/grub/grubenv
 	mkdir -p /boot/grub
 	grub-editenv /boot/grub/grubenv unset recordfail
+	if [ -s "/boot/efi/EFI/ubuntu/grub/grubenv" ]; then
+		grub-editenv /boot/efi/EFI/ubuntu/grub/grubenv unset recordfail
+	fi
 	log_end_msg $?
 	;;
     stop)

--- a/debian/grub-common.pm-sleep
+++ b/debian/grub-common.pm-sleep
@@ -7,5 +7,8 @@ case "$1" in
 		[ -s /boot/grub/grubenv ] || rm -f /boot/grub/grubenv
 		mkdir -p /boot/grub
 		grub-editenv /boot/grub/grubenv unset recordfail
+		if [ -s "/boot/efi/EFI/ubuntu/grub/grubenv" ]; then
+			grub-editenv /boot/efi/EFI/ubuntu/grub/grubenv unset recordfail
+		fi
 		;;
 esac


### PR DESCRIPTION
Fixes #178 

Similar to #196 

The `recordfail` function of GRUB stores a flag in an environment file on every boot, which is then cleared by an init script or a wake script. If it's not cleared, the previous boot can be assumed to be a failure which then shows the GRUB menu on the next boot.

Since distinst is installing GRUB to a different location, we need to have the clearing scripts clear that location too.