### PR TITLE
packages_to_import: add python-apt

### DIFF
--- a/jammy/packages_to_import
+++ b/jammy/packages_to_import
@@ -2,3 +2,4 @@ base-files
 dkms
 grub2
 lsb
+python-apt


### PR DESCRIPTION
Looks like we got a successful build: https://code.launchpad.net/~elementary-os/+recipe/python-apt-jammy