### PR TITLE
packages_to_import: add casper

### DIFF
--- a/jammy/packages_to_import
+++ b/jammy/packages_to_import
@@ -1,4 +1,5 @@
 base-files
+casper
 dkms
 grub2
 lsb


### PR DESCRIPTION
I've tested and validated this patch to fix the issue of the installer not launching on the live image by creating the live session user as UID 1000 instead of 999. If we want to take this approach to fix this issue, we'll need to monitor the casper package for changes, so we can keep it up to date.

`casper` is only installed in the live session, so this will have no impact on installed systems.

https://github.com/elementary/os-patches/compare/casper-jammy...casper-jammy-patched

Related: https://github.com/elementary/greeter/issues/600