### PR TITLE
Revert "Use upstream flag for lsb_release" on dkms

### DIFF
--- a/dkms_common.postinst
+++ b/dkms_common.postinst
@@ -201,7 +201,7 @@ echo "Building for $KERNELS" | tr '\n' ',' \
     | sed -e 's/,/, /g; s/, $/\n/; s/, \([^,]\+\)$/ and \1/'
 
 if [ -n "$ARCH" ]; then
-    if which lsb_release >/dev/null && [ $(lsb_release -s -i) = "Ubuntu" ]; then
+    if which lsb_release >/dev/null && [ $(LSB_OS_RELEASE="/usr/lib/upstream-os-release" lsb_release -s -i) = "Ubuntu" ]; then
         case $ARCH in
             amd64)
                 ARCH="x86_64"

--- a/dkms_common.postinst
+++ b/dkms_common.postinst
@@ -201,7 +201,7 @@ echo "Building for $KERNELS" | tr '\n' ',' \
     | sed -e 's/,/, /g; s/, $/\n/; s/, \([^,]\+\)$/ and \1/'
 
 if [ -n "$ARCH" ]; then
-    if which lsb_release >/dev/null && [ $(lsb_release -s -i -u) = "Ubuntu" ]; then
+    if which lsb_release >/dev/null && [ $(lsb_release -s -i) = "Ubuntu" ]; then
         case $ARCH in
             amd64)
                 ARCH="x86_64"


### PR DESCRIPTION
I believe the DKMS patch for Jammy should be dropped as the flag it adds is [no longer in use for Jammy](https://github.com/elementary/os-patches/commit/f37a8064ab7849356e340a7c6dbdb9b8cb8f47bc).

For most users I imagine DKMS will be run as part of installing drivers via apt, thus the existing patches in apt adding the  `LSB_OS_RELEASE` environment variable should be sufficient at passing the check.

It might be possible to drop this package entirely from the os-patches repository as this was the only patch on it, but that might not play well with existing installations. Reverting and building an update seems safer. 
Was going to make an issue, but as it is a small change just made this pr.