### PR TITLE
Rebase bash_preexec to upstream 0.5.0 release

### DIFF
--- a/debian/etc.bash_preexec
+++ b/debian/etc.bash_preexec
@@ -26,13 +26,13 @@
 #
 #
 # 'preexec' functions are executed before each interactive command is
-# executed, with the interactive command as its argument.  The 'precmd'
+# executed, with the interactive command as its argument. The 'precmd'
 # function is executed before each prompt is displayed.
 #
 # Author: Ryan Caloras (ryan@bashhub.com)
 # Forked from Original Author: Glyph Lefkowitz
 #
-# V0.2.1
+# V0.5.0
 #
 
 # General Usage:
@@ -47,20 +47,69 @@
 #
 #       preexec_functions+=(my_preexec_function)
 #
-#  3. If you have anything that's using the Debug Trap, change it to use
-#     preexec. (Optional) change anything using PROMPT_COMMAND to now use
-#     precmd instead.
+#  3. Consider changing anything using the DEBUG trap or PROMPT_COMMAND
+#     to use preexec and precmd instead. Preexisting usages will be
+#     preserved, but doing so manually may be less surprising.
 #
-#  Note: This module requires two bash features which you must not otherwise be
-#  using: the "DEBUG" trap, and the "PROMPT_COMMAND" variable. prexec_and_precmd_install
-#  will override these and if you override one or the other after the file is sourced
-#  this will most likely break.
+#  Note: This module requires two Bash features which you must not otherwise be
+#  using: the "DEBUG" trap, and the "PROMPT_COMMAND" variable. If you override
+#  either of these after bash-preexec has been installed it will most likely break.
+
+# Make sure this is bash that's running and return otherwise.
+if [[ -z "${BASH_VERSION:-}" ]]; then
+    return 1;
+fi
 
 # Avoid duplicate inclusion
-if [[ "$__bp_imported" == "defined" ]]; then
+if [[ -n "${bash_preexec_imported:-}" ]]; then
     return 0
 fi
-__bp_imported="defined"
+bash_preexec_imported="defined"
+
+# WARNING: This variable is no longer used and should not be relied upon.
+# Use ${bash_preexec_imported} instead.
+__bp_imported="${bash_preexec_imported}"
+
+# Should be available to each precmd and preexec
+# functions, should they want it. $? and $_ are available as $? and $_, but
+# $PIPESTATUS is available only in a copy, $BP_PIPESTATUS.
+# TODO: Figure out how to restore PIPESTATUS before each precmd or preexec
+# function.
+__bp_last_ret_value="$?"
+BP_PIPESTATUS=("${PIPESTATUS[@]}")
+__bp_last_argument_prev_command="$_"
+
+__bp_inside_precmd=0
+__bp_inside_preexec=0
+
+# Initial PROMPT_COMMAND string that is removed from PROMPT_COMMAND post __bp_install
+__bp_install_string=$'__bp_trap_string="$(trap -p DEBUG)"\ntrap - DEBUG\n__bp_install'
+
+# Fails if any of the given variables are readonly
+# Reference https://stackoverflow.com/a/4441178
+__bp_require_not_readonly() {
+  local var
+  for var; do
+    if ! ( unset "$var" 2> /dev/null ); then
+      echo "bash-preexec requires write access to ${var}" >&2
+      return 1
+    fi
+  done
+}
+
+# Remove ignorespace and or replace ignoreboth from HISTCONTROL
+# so we can accurately invoke preexec with a command from our
+# history even if it starts with a space.
+__bp_adjust_histcontrol() {
+    local histcontrol
+    histcontrol="${HISTCONTROL:-}"
+    histcontrol="${histcontrol//ignorespace}"
+    # Replace ignoreboth with ignoredups
+    if [[ "$histcontrol" == *"ignoreboth"* ]]; then
+        histcontrol="ignoredups:${histcontrol//ignoreboth}"
+    fi;
+    export HISTCONTROL="$histcontrol"
+}
 
 # This variable describes whether we are currently in "interactive mode";
 # i.e. whether this shell has just executed a prompt and is waiting for user
@@ -68,13 +117,31 @@ __bp_imported="defined"
 # run interactively by the user; it's set immediately after the prompt hook,
 # and unset as soon as the trace hook is run.
 __bp_preexec_interactive_mode=""
-__bp_last_ret_value=""
 
+# These arrays are used to add functions to be run before, or after, prompts.
+declare -a precmd_functions
+declare -a preexec_functions
+
+# Trims leading and trailing whitespace from $2 and writes it to the variable
+# name passed as $1
 __bp_trim_whitespace() {
-    local var=$@
-    var="${var#"${var%%[![:space:]]*}"}"   # remove leading whitespace characters
-    var="${var%"${var##*[![:space:]]}"}"   # remove trailing whitespace characters
-    echo -n "$var"
+    local var=${1:?} text=${2:-}
+    text="${text#"${text%%[![:space:]]*}"}"   # remove leading whitespace characters
+    text="${text%"${text##*[![:space:]]}"}"   # remove trailing whitespace characters
+    printf -v "$var" '%s' "$text"
+}
+
+
+# Trims whitespace and removes any leading or trailing semicolons from $2 and
+# writes the resulting string to the variable name passed as $1. Used for
+# manipulating substrings in PROMPT_COMMAND
+__bp_sanitize_string() {
+    local var=${1:?} text=${2:-} sanitized
+    __bp_trim_whitespace sanitized "$text"
+    sanitized=${sanitized%;}
+    sanitized=${sanitized#;}
+    __bp_trim_whitespace sanitized "$sanitized"
+    printf -v "$var" '%s' "$sanitized"
 }
 
 # This function is installed as part of the PROMPT_COMMAND;
@@ -88,42 +155,52 @@ __bp_interactive_mode() {
 # This function is installed as part of the PROMPT_COMMAND.
 # It will invoke any functions defined in the precmd_functions array.
 __bp_precmd_invoke_cmd() {
+    # Save the returned value from our last command, and from each process in
+    # its pipeline. Note: this MUST be the first thing done in this function.
+    __bp_last_ret_value="$?" BP_PIPESTATUS=("${PIPESTATUS[@]}")
 
-    # Should be available to each precmd function, should it want it.
-    __bp_last_ret_value="$?"
+    # Don't invoke precmds if we are inside an execution of an "original
+    # prompt command" by another precmd execution loop. This avoids infinite
+    # recursion.
+    if (( __bp_inside_precmd > 0 )); then
+      return
+    fi
+    local __bp_inside_precmd=1
 
-    # For every function defined in our function array. Invoke it.
+    # Invoke every function defined in our function array.
     local precmd_function
-    for precmd_function in ${precmd_functions[@]}; do
+    for precmd_function in "${precmd_functions[@]}"; do
 
         # Only execute this function if it actually exists.
-        if [[ -n $(type -t $precmd_function) ]]; then
-            __bp_set_ret_value $__bp_last_ret_value
-            $precmd_function
+        # Test existence of functions with: declare -[Ff]
+        if type -t "$precmd_function" 1>/dev/null; then
+            __bp_set_ret_value "$__bp_last_ret_value" "$__bp_last_argument_prev_command"
+            # Quote our function invocation to prevent issues with IFS
+            "$precmd_function"
         fi
     done
+
+    __bp_set_ret_value "$__bp_last_ret_value"
 }
 
 # Sets a return value in $?. We may want to get access to the $? variable in our
 # precmd functions. This is available for instance in zsh. We can simulate it in bash
 # by setting the value here.
 __bp_set_ret_value() {
-    return $1
+    return ${1:-}
 }
 
 __bp_in_prompt_command() {
 
     local prompt_command_array
-    IFS=';' read -ra prompt_command_array <<< "$PROMPT_COMMAND"
+    IFS=$'\n;' read -rd '' -a prompt_command_array <<< "${PROMPT_COMMAND:-}"
 
     local trimmed_arg
-    trimmed_arg=$(__bp_trim_whitespace "$1")
+    __bp_trim_whitespace trimmed_arg "${1:-}"
 
-    local prompt_command_function
-    for command in "${prompt_command_array[@]}"; do
-        local trimmed_command
-        trimmed_command=$(__bp_trim_whitespace "$command")
-        # Only execute each function if it actually exists.
+    local command trimmed_command
+    for command in "${prompt_command_array[@]:-}"; do
+        __bp_trim_whitespace trimmed_command "$command"
         if [[ "$trimmed_command" == "$trimmed_arg" ]]; then
             return 0
         fi
@@ -138,14 +215,28 @@ __bp_in_prompt_command() {
 # interactively, and invoke 'preexec' if so.
 __bp_preexec_invoke_exec() {
 
-    if [[ -n "$COMP_LINE" ]]
-    then
-        # We're in the middle of a completer.  This obviously can't be
+    # Save the contents of $_ so that it can be restored later on.
+    # https://stackoverflow.com/questions/40944532/bash-preserve-in-a-debug-trap#40944702
+    __bp_last_argument_prev_command="${1:-}"
+    # Don't invoke preexecs if we are inside of another preexec.
+    if (( __bp_inside_preexec > 0 )); then
+      return
+    fi
+    local __bp_inside_preexec=1
+
+    # Checks if the file descriptor is not standard out (i.e. '1')
+    # __bp_delay_install checks if we're in test. Needed for bats to run.
+    # Prevents preexec from being invoked for functions in PS1
+    if [[ ! -t 1 && -z "${__bp_delay_install:-}" ]]; then
+        return
+    fi
+
+    if [[ -n "${COMP_LINE:-}" ]]; then
+        # We're in the middle of a completer. This obviously can't be
         # an interactively issued command.
         return
     fi
-    if [[ -z "$__bp_preexec_interactive_mode" ]]
-    then
+    if [[ -z "${__bp_preexec_interactive_mode:-}" ]]; then
         # We're doing something related to displaying the prompt.  Let the
         # prompt set the title instead of me.
         return
@@ -155,76 +246,131 @@ __bp_preexec_invoke_exec() {
         # In other words, if you have a subshell like
         #   (sleep 1; sleep 2)
         # You want to see the 'sleep 2' as a set_command_title as well.
-        if [[ 0 -eq "$BASH_SUBSHELL" ]]
-        then
+        if [[ 0 -eq "${BASH_SUBSHELL:-}" ]]; then
             __bp_preexec_interactive_mode=""
         fi
     fi
 
-    if  __bp_in_prompt_command "$BASH_COMMAND"; then
+    if  __bp_in_prompt_command "${BASH_COMMAND:-}"; then
         # If we're executing something inside our prompt_command then we don't
         # want to call preexec. Bash prior to 3.1 can't detect this at all :/
-
         __bp_preexec_interactive_mode=""
         return
     fi
 
-    local this_command="$(history 1 | sed -e "s/^[ ]*[0-9]*[ ]*//g")";
+    local this_command
+    this_command=$(
+        export LC_ALL=C
+        HISTTIMEFORMAT= builtin history 1 | sed '1 s/^ *[0-9][0-9]*[* ] //'
+    )
 
     # Sanity check to make sure we have something to invoke our function with.
-    if [ -z "$this_command" ]; then
+    if [[ -z "$this_command" ]]; then
         return
     fi
 
-    # If none of the previous checks have returned out of this function, then
-    # the command is in fact interactive and we should invoke the user's
-    # preexec functions.
-
-    # For every function defined in our function array. Invoke it.
+    # Invoke every function defined in our function array.
     local preexec_function
-    for preexec_function in "${preexec_functions[@]}"; do
+    local preexec_function_ret_value
+    local preexec_ret_value=0
+    for preexec_function in "${preexec_functions[@]:-}"; do
 
         # Only execute each function if it actually exists.
-        if [[ -n $(type -t $preexec_function) ]]; then
-            $preexec_function "$this_command"
+        # Test existence of function with: declare -[fF]
+        if type -t "$preexec_function" 1>/dev/null; then
+            __bp_set_ret_value ${__bp_last_ret_value:-}
+            # Quote our function invocation to prevent issues with IFS
+            "$preexec_function" "$this_command"
+            preexec_function_ret_value="$?"
+            if [[ "$preexec_function_ret_value" != 0 ]]; then
+                preexec_ret_value="$preexec_function_ret_value"
+            fi
         fi
     done
+
+    # Restore the last argument of the last executed command, and set the return
+    # value of the DEBUG trap to be the return code of the last preexec function
+    # to return an error.
+    # If `extdebug` is enabled a non-zero return value from any preexec function
+    # will cause the user's command not to execute.
+    # Run `shopt -s extdebug` to enable
+    __bp_set_ret_value "$preexec_ret_value" "$__bp_last_argument_prev_command"
 }
 
-# Execute this to set up preexec and precmd execution.
-__bp_preexec_and_precmd_install() {
-
-    # Make sure this is bash that's running this and return otherwise.
-    if [ -z "$BASH_VERSION" ]; then
-        return 1;
-    fi
-
+__bp_install() {
     # Exit if we already have this installed.
-    if [[ "$PROMPT_COMMAND" == *"__bp_precmd_invoke_cmd"* ]]; then
+    if [[ "${PROMPT_COMMAND:-}" == *"__bp_precmd_invoke_cmd"* ]]; then
         return 1;
     fi
 
-    # Take our existing prompt command and append a semicolon to it
-    # if it doesn't already have one.
-    local existing_prompt_command
+    trap '__bp_preexec_invoke_exec "$_"' DEBUG
 
-    if [ -n "$PROMPT_COMMAND" ]; then
-        existing_prompt_command=$(echo "$PROMPT_COMMAND" | sed '/; *$/!s/$/;/')
-    else
-        existing_prompt_command=""
+    # Preserve any prior DEBUG trap as a preexec function
+    local prior_trap=$(sed "s/[^']*'\(.*\)'[^']*/\1/" <<<"${__bp_trap_string:-}")
+    unset __bp_trap_string
+    if [[ -n "$prior_trap" ]]; then
+        eval '__bp_original_debug_trap() {
+          '"$prior_trap"'
+        }'
+        preexec_functions+=(__bp_original_debug_trap)
     fi
 
-    # Finally install our traps.
-    PROMPT_COMMAND="__bp_precmd_invoke_cmd; ${existing_prompt_command} __bp_interactive_mode;"
-    trap '__bp_preexec_invoke_exec' DEBUG;
+    # Adjust our HISTCONTROL Variable if needed.
+    __bp_adjust_histcontrol
+
+    # Issue #25. Setting debug trap for subshells causes sessions to exit for
+    # backgrounded subshell commands (e.g. (pwd)& ). Believe this is a bug in Bash.
+    #
+    # Disabling this by default. It can be enabled by setting this variable.
+    if [[ -n "${__bp_enable_subshells:-}" ]]; then
+
+        # Set so debug trap will work be invoked in subshells.
+        set -o functrace > /dev/null 2>&1
+        shopt -s extdebug > /dev/null 2>&1
+    fi;
+
+    local existing_prompt_command
+    # Remove setting our trap install string and sanitize the existing prompt command string
+    existing_prompt_command="${PROMPT_COMMAND:-}"
+    existing_prompt_command="${existing_prompt_command//$__bp_install_string[;$'\n']}" # Edge case of appending to PROMPT_COMMAND
+    existing_prompt_command="${existing_prompt_command//$__bp_install_string}"
+    __bp_sanitize_string existing_prompt_command "$existing_prompt_command"
+
+    # Install our hooks in PROMPT_COMMAND to allow our trap to know when we've
+    # actually entered something.
+    PROMPT_COMMAND=$'__bp_precmd_invoke_cmd\n'
+    if [[ -n "$existing_prompt_command" ]]; then
+        PROMPT_COMMAND+=${existing_prompt_command}$'\n'
+    fi;
+    PROMPT_COMMAND+='__bp_interactive_mode'
 
     # Add two functions to our arrays for convenience
     # of definition.
     precmd_functions+=(precmd)
     preexec_functions+=(preexec)
+
+    # Invoke our two functions manually that were added to $PROMPT_COMMAND
+    __bp_precmd_invoke_cmd
+    __bp_interactive_mode
+}
+
+# Sets an installation string as part of our PROMPT_COMMAND to install
+# after our session has started. This allows bash-preexec to be included
+# at any point in our bash profile.
+__bp_install_after_session_init() {
+    # bash-preexec needs to modify these variables in order to work correctly
+    # if it can't, just stop the installation
+    __bp_require_not_readonly PROMPT_COMMAND HISTCONTROL HISTTIMEFORMAT || return
+
+    local sanitized_prompt_command
+    __bp_sanitize_string sanitized_prompt_command "${PROMPT_COMMAND:-}"
+    if [[ -n "$sanitized_prompt_command" ]]; then
+        PROMPT_COMMAND=${sanitized_prompt_command}$'\n'
+    fi;
+    PROMPT_COMMAND+=${__bp_install_string}
 }
 
 # Run our install so long as we're not delaying it.
-if [[ -z "$__bp_delay_install" ]]; then
-    __bp_preexec_and_precmd_install
+if [[ -z "${__bp_delay_install:-}" ]]; then
+    __bp_install_after_session_init
 fi;


### PR DESCRIPTION
Fixes #85

Rebased bash_preexec on https://github.com/rcaloras/bash-preexec/commit/da64ad4b7bb965d19dbeb5bb7447f1a63e3de2e3, while preserving the copyright header.

### Tests
- [x] Confirmed that the issue no longer happens

```
ryo@b760m:~/work/tmp/os-patches$ git rev-parse HEAD
ebf9032f2713876248c784e124329562c96a23ad
ryo@b760m:~/work/tmp/os-patches$ sudo cp ~/work/tmp/os-patches/debian/etc.bash_preexec /etc/bash_preexec
ryo@b760m:~/work/tmp/os-patches$ exec bash
ryo@b760m:~/work/tmp/os-patches$ cd ~/Downloads/
ryo@b760m:~/Downloads$ cd $_
ryo@b760m:~/Downloads$ 
exit
```

- [x] Confirmed that #290 does not happen (regression test)