### PR TITLE
Reimport grub2_2.12-1ubuntu7 from packages.ubuntu.com

### DIFF
--- a/grub-core/term/ns8250-spcr.c
+++ b/grub-core/term/ns8250-spcr.c
@@ -1,0 +1,90 @@
+/*
+ *  GRUB  --  GRand Unified Bootloader
+ *  Copyright (C) 2022  Free Software Foundation, Inc.
+ *
+ *  GRUB is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  GRUB is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if !defined(GRUB_MACHINE_IEEE1275) && !defined(GRUB_MACHINE_QEMU)
+
+#include <grub/misc.h>
+#include <grub/serial.h>
+#include <grub/ns8250.h>
+#include <grub/types.h>
+#include <grub/dl.h>
+#include <grub/acpi.h>
+
+struct grub_serial_port *
+grub_ns8250_spcr_init (void)
+{
+  struct grub_acpi_spcr *spcr;
+  struct grub_serial_config config;
+
+  spcr = grub_acpi_find_table (GRUB_ACPI_SPCR_SIGNATURE);
+  if (spcr == NULL)
+    return NULL;
+  if (spcr->hdr.revision < 2)
+    grub_dprintf ("serial", "SPCR table revision %d < 2, continuing anyway\n",
+		  (int) spcr->hdr.revision);
+  if (spcr->intf_type != GRUB_ACPI_SPCR_INTF_TYPE_16550 &&
+      spcr->intf_type != GRUB_ACPI_SPCR_INTF_TYPE_16550X)
+    return NULL;
+  /* For now, we only support byte accesses. */
+  if (spcr->base_addr.access_size != GRUB_ACPI_GENADDR_SIZE_BYTE &&
+      spcr->base_addr.access_size != GRUB_ACPI_GENADDR_SIZE_LGCY)
+    return NULL;
+  config.word_len = 8;
+  config.parity = GRUB_SERIAL_PARITY_NONE;
+  config.stop_bits = GRUB_SERIAL_STOP_BITS_1;
+  config.base_clock = UART_DEFAULT_BASE_CLOCK;
+  if (spcr->flow_control & GRUB_ACPI_SPCR_FC_RTSCTS)
+    config.rtscts = 1;
+  else
+    config.rtscts = 0;
+  switch (spcr->baud_rate)
+    {
+      case GRUB_ACPI_SPCR_BAUD_9600:
+        config.speed = 9600;
+        break;
+      case GRUB_ACPI_SPCR_BAUD_19200:
+        config.speed = 19200;
+        break;
+      case GRUB_ACPI_SPCR_BAUD_57600:
+        config.speed = 57600;
+        break;
+      case GRUB_ACPI_SPCR_BAUD_115200:
+        config.speed = 115200;
+        break;
+      case GRUB_ACPI_SPCR_BAUD_CURRENT:
+      default:
+       /*
+        * We don't (yet) have a way to read the currently
+        * configured speed in HW, so let's use a sane default.
+        */
+        config.speed = 115200;
+        break;
+    };
+  switch (spcr->base_addr.space_id)
+    {
+      case GRUB_ACPI_GENADDR_MEM_SPACE:
+        return grub_serial_ns8250_add_mmio (spcr->base_addr.addr,
+                                            spcr->base_addr.access_size, &config);
+      case GRUB_ACPI_GENADDR_IO_SPACE:
+        return grub_serial_ns8250_add_port (spcr->base_addr.addr, &config);
+      default:
+        return NULL;
+    };
+}
+
+#endif

--- a/include/grub/ieee1275/alloc.h
+++ b/include/grub/ieee1275/alloc.h
@@ -1,0 +1,39 @@
+/* alloc.h - Memory allocation for PowerVM, KVM on Power, and i386 */
+/*
+ *  GRUB  --  GRand Unified Bootloader
+ *  Copyright (C) 2023  Free Software Foundation, Inc.
+ *  Copyright (C) 2023  IBM Corporation
+ *
+ *  GRUB is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  GRUB is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef GRUB_IEEE1275_ALLOC_HEADER
+#define GRUB_IEEE1275_ALLOC_HEADER	1
+
+#include <stdbool.h>
+
+#include <grub/memory.h>
+
+struct regions_claim_request {
+  unsigned int flags;     /* GRUB_MM_ADD_REGION_(NONE|CONSECUTIVE) */
+  grub_uint32_t total;    /* number of requested bytes */
+  bool init_region;       /* whether to add memory to the heap using grub_mm_init_region() */
+  grub_uint64_t addr;     /* result address */
+  grub_size_t align;      /* alignment restrictions */
+};
+
+int EXPORT_FUNC(grub_regions_claim) (grub_uint64_t addr, grub_uint64_t len,
+				     grub_memory_type_t type, void *data);
+
+#endif /* GRUB_IEEE1275_ALLOC_HEADER */


### PR DESCRIPTION
This fixes the debuild of grub2 fails (and hopefully fixes [the LP build failing](https://code.launchpad.net/~elementary-os/+archive/ubuntu/os-patches/+recipebuild/3771554); rebase `grub2-noble-patched` on `grub2-noble` after merging this branch)

```
user@VirtualBox-4c0cd87a:~/work/os-patches$ debuild -us -uc
:

dpkg-source: warning: diff os-patches/debian/patches/revert-term-ns8250-spcr.patch removes a non-existing file os-patches/grub-core/term/ns8250-spcr.c (line 59)
dpkg-source: info: applying revert-term-ns8250-spcr.patch
patching file docs/grub.texi
patching file grub-core/Makefile.core.def
The next patch would delete the file grub-core/term/ns8250-spcr.c,
which does not exist!  Skipping patch.
1 out of 1 hunk ignored
patching file grub-core/term/serial.c
patching file include/grub/serial.h
dpkg-source: info: the patch has fuzz which is not allowed, or is malformed
dpkg-source: info: if patch 'revert-term-ns8250-spcr.patch' is correctly applied by quilt, use 'quilt refresh' to update it
dpkg-source: info: if the file is present in the unpacked source, make sure it is also present in the orig tarball
dpkg-source: info: restoring quilt backup files for revert-term-ns8250-spcr.patch
dpkg-source: error: LC_ALL=C patch -t -F 0 -N -p1 -u -V never -E -b -B .pc/revert-term-ns8250-spcr.patch/ --reject-file=- < os-patches/debian/patches/revert-term-ns8250-spcr.patch subprocess returned exit status 1
dpkg-buildpackage: error: dpkg-source --before-build . subprocess returned exit status 2
debuild: fatal error at line 1184:
dpkg-buildpackage -us -uc -ui failed
user@VirtualBox-4c0cd87a:~/work/os-patches$
```