### PR TITLE
Fix getting latest version

### DIFF
--- a/.github/workflows/horus.yml
+++ b/.github/workflows/horus.yml
@@ -10,6 +10,9 @@ jobs:
     container:
       image: ghcr.io/elementary/docker:stable
 
+    env:
+      PACKAGES_TO_IMPORT_PATH: '/tmp/patched-packages'
+
     steps:
     - name: Checkout the import-list
       uses: actions/checkout@v4
@@ -18,7 +21,7 @@ jobs:
         fetch-depth: 1
     - name: Get the list of packages
       run: |
-        cp jammy/packages_to_import /tmp/patched-packages
+        cp jammy/packages_to_import $PACKAGES_TO_IMPORT_PATH
     - name: Install dependencies and enable sources
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources

--- a/.github/workflows/horus.yml
+++ b/.github/workflows/horus.yml
@@ -19,11 +19,13 @@ jobs:
     - name: Get the list of packages
       run: |
         cp jammy/packages_to_import /tmp/patched-packages
-    - name: Install Dependencies
+    - name: Install Dependencies and enable Sources
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update
-        apt install -y git python3-launchpadlib python3-apt python3-github
+        apt install -y git python3-launchpadlib python3-apt python3-github python3-pip
+        pip install --break-system-packages GitPython
+
     - name: Checkout the repository
       uses: actions/checkout@v4
       with:
@@ -32,8 +34,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_REPOSITORY: ${{ github.event.repository.name }}
-      run: |
-        while IFS=":" read -r line upstream_series; do
-            echo "Checking version for $line"
-            python3 ./get-latest-version.py "$line" "jammy" "$upstream_series"
-        done < "/tmp/patched-packages"
+      run: python3 get-latest-version.py "jammy"

--- a/.github/workflows/horus.yml
+++ b/.github/workflows/horus.yml
@@ -23,8 +23,7 @@ jobs:
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update
-        apt install -y git python3-launchpadlib python3-apt python3-github python3-pip
-        pip install --break-system-packages GitPython
+        apt install -y git python3-launchpadlib python3-apt python3-github python3-pip python3-git
 
     - name: Checkout the repository
       uses: actions/checkout@v4

--- a/.github/workflows/horus.yml
+++ b/.github/workflows/horus.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Get the list of packages
       run: |
         cp jammy/packages_to_import /tmp/patched-packages
-    - name: Install Dependencies and enable Sources
+    - name: Install dependencies and enable sources
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update

--- a/.github/workflows/horus.yml
+++ b/.github/workflows/horus.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update
-        apt install -y git python3-launchpadlib python3-apt python3-github python3-pip python3-git
+        apt install -y git python3-launchpadlib python3-apt python3-github python3-git
 
     - name: Checkout the repository
       uses: actions/checkout@v4

--- a/.github/workflows/juno.yml
+++ b/.github/workflows/juno.yml
@@ -23,8 +23,7 @@ jobs:
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update
-        apt install -y git python3-launchpadlib python3-apt python3-github python3-pip
-        pip install --break-system-packages GitPython
+        apt install -y git python3-launchpadlib python3-apt python3-github python3-pip python3-git
 
     - name: Checkout the repository
       uses: actions/checkout@v4

--- a/.github/workflows/juno.yml
+++ b/.github/workflows/juno.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update
-        apt install -y git python3-launchpadlib python3-apt python3-github python3-pip python3-git
+        apt install -y git python3-launchpadlib python3-apt python3-github python3-git
 
     - name: Checkout the repository
       uses: actions/checkout@v4

--- a/.github/workflows/juno.yml
+++ b/.github/workflows/juno.yml
@@ -19,11 +19,13 @@ jobs:
     - name: Get the list of packages
       run: |
         cp bionic/packages_to_import /tmp/patched-packages
-    - name: Install Dependencies
+    - name: Install Dependencies and enable Sources
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update
-        apt install -y git python3-launchpadlib python3-apt python3-github
+        apt install -y git python3-launchpadlib python3-apt python3-github python3-pip
+        pip install --break-system-packages GitPython
+
     - name: Checkout the repository
       uses: actions/checkout@v4
       with:
@@ -32,8 +34,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_REPOSITORY: ${{ github.event.repository.name }}
-      run: |
-        while IFS=":" read -r line upstream_series; do
-            echo "Checking version for $line"
-            python3 ./get-latest-version.py "$line" "bionic" "$upstream_series"
-        done < "/tmp/patched-packages"
+      run: python3 get-latest-version.py "bionic"

--- a/.github/workflows/juno.yml
+++ b/.github/workflows/juno.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Get the list of packages
       run: |
         cp bionic/packages_to_import /tmp/patched-packages
-    - name: Install Dependencies and enable Sources
+    - name: Install dependencies and enable sources
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update

--- a/.github/workflows/juno.yml
+++ b/.github/workflows/juno.yml
@@ -10,6 +10,9 @@ jobs:
     container:
       image: ghcr.io/elementary/docker:stable
 
+    env:
+      PACKAGES_TO_IMPORT_PATH: '/tmp/patched-packages'
+
     steps:
     - name: Checkout the import-list
       uses: actions/checkout@v4
@@ -18,7 +21,7 @@ jobs:
         fetch-depth: 1
     - name: Get the list of packages
       run: |
-        cp bionic/packages_to_import /tmp/patched-packages
+        cp bionic/packages_to_import $PACKAGES_TO_IMPORT_PATH
     - name: Install dependencies and enable sources
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources

--- a/.github/workflows/noble.yml
+++ b/.github/workflows/noble.yml
@@ -23,7 +23,9 @@ jobs:
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update
-        apt install -y git python3-launchpadlib python3-apt python3-github
+        apt install -y git python3-launchpadlib python3-apt python3-github python3-pip
+        pip install --break-system-packages GitPython
+
     - name: Checkout the repository
       uses: actions/checkout@v4
       with:
@@ -32,8 +34,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_REPOSITORY: ${{ github.event.repository.name }}
-      run: |
-        while IFS=":" read -r line upstream_series; do
-            echo "Checking version for $line"
-            python3 ./get-latest-version.py "$line" "noble" "$upstream_series"
-        done < "/tmp/patched-packages"
+      run: python3 get-latest-version.py "noble"

--- a/.github/workflows/noble.yml
+++ b/.github/workflows/noble.yml
@@ -23,8 +23,7 @@ jobs:
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update
-        apt install -y git python3-launchpadlib python3-apt python3-github python3-pip
-        pip install --break-system-packages GitPython
+        apt install -y git python3-launchpadlib python3-apt python3-github python3-pip python3-git
 
     - name: Checkout the repository
       uses: actions/checkout@v4

--- a/.github/workflows/noble.yml
+++ b/.github/workflows/noble.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update
-        apt install -y git python3-launchpadlib python3-apt python3-github python3-pip python3-git
+        apt install -y git python3-launchpadlib python3-apt python3-github python3-git
 
     - name: Checkout the repository
       uses: actions/checkout@v4

--- a/.github/workflows/noble.yml
+++ b/.github/workflows/noble.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Get the list of packages
       run: |
         cp noble/packages_to_import /tmp/patched-packages
-    - name: Install Dependencies and enable Sources
+    - name: Install dependencies and enable sources
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update

--- a/.github/workflows/noble.yml
+++ b/.github/workflows/noble.yml
@@ -10,16 +10,21 @@ jobs:
     container:
       image: ghcr.io/elementary/docker:stable
 
+    env:
+      PACKAGES_TO_IMPORT_PATH: '/tmp/patched-packages'
+
     steps:
     - name: Checkout the import-list
       uses: actions/checkout@v4
       with:
         ref: import-list-noble
         fetch-depth: 1
+
     - name: Get the list of packages
       run: |
-        cp noble/packages_to_import /tmp/patched-packages
-    - name: Install dependencies and enable sources
+        cp noble/packages_to_import $PACKAGES_TO_IMPORT_PATH
+
+    - name: Install Dependencies and enable Sources
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update
@@ -29,6 +34,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 1
+
     - name: Verify that we are shipping the latest version
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/odin.yml
+++ b/.github/workflows/odin.yml
@@ -19,11 +19,13 @@ jobs:
     - name: Get the list of packages
       run: |
         cp focal/packages_to_import /tmp/patched-packages
-    - name: Install Dependencies
+    - name: Install Dependencies and enable Sources
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update
-        apt install -y git python3-launchpadlib python3-apt python3-github
+        apt install -y git python3-launchpadlib python3-apt python3-github python3-pip
+        pip install --break-system-packages GitPython
+
     - name: Checkout the repository
       uses: actions/checkout@v4
       with:
@@ -32,8 +34,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_REPOSITORY: ${{ github.event.repository.name }}
-      run: |
-        while IFS=":" read -r line upstream_series; do
-            echo "Checking version for $line"
-            python3 ./get-latest-version.py "$line" "focal" "$upstream_series"
-        done < "/tmp/patched-packages"
+      run: python3 get-latest-version.py "focal"

--- a/.github/workflows/odin.yml
+++ b/.github/workflows/odin.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Get the list of packages
       run: |
         cp focal/packages_to_import /tmp/patched-packages
-    - name: Install Dependencies and enable Sources
+    - name: Install dependencies and enable sources
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update

--- a/.github/workflows/odin.yml
+++ b/.github/workflows/odin.yml
@@ -23,8 +23,7 @@ jobs:
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update
-        apt install -y git python3-launchpadlib python3-apt python3-github python3-pip
-        pip install --break-system-packages GitPython
+        apt install -y git python3-launchpadlib python3-apt python3-github python3-pip python3-git
 
     - name: Checkout the repository
       uses: actions/checkout@v4

--- a/.github/workflows/odin.yml
+++ b/.github/workflows/odin.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         apt update
-        apt install -y git python3-launchpadlib python3-apt python3-github python3-pip python3-git
+        apt install -y git python3-launchpadlib python3-apt python3-github python3-git
 
     - name: Checkout the repository
       uses: actions/checkout@v4

--- a/.github/workflows/odin.yml
+++ b/.github/workflows/odin.yml
@@ -10,6 +10,9 @@ jobs:
     container:
       image: ghcr.io/elementary/docker:stable
 
+    env:
+      PACKAGES_TO_IMPORT_PATH: '/tmp/patched-packages'
+
     steps:
     - name: Checkout the import-list
       uses: actions/checkout@v4
@@ -18,7 +21,7 @@ jobs:
         fetch-depth: 1
     - name: Get the list of packages
       run: |
-        cp focal/packages_to_import /tmp/patched-packages
+        cp focal/packages_to_import $PACKAGES_TO_IMPORT_PATH
     - name: Install dependencies and enable sources
       run: |
         sed -i 's/^\(Types: deb\)$/\1 deb-src/g' /etc/apt/sources.list.d/ubuntu.sources

--- a/get-latest-version.py
+++ b/get-latest-version.py
@@ -62,6 +62,7 @@ def main():
     )
 
     packages_and_upstream = get_packages_list()
+    series = ubuntu.getSeries(name_or_version=series_name)
 
     for package_and_upstream in packages_and_upstream:
         package_name, *upstream_series_name = package_and_upstream.split(":", 1)
@@ -69,8 +70,7 @@ def main():
             upstream_series_name[0] if upstream_series_name else series_name
         )
         print(package_name, upstream_series_name)
-
-        series = ubuntu.getSeries(name_or_version=series_name)
+        
         upstream_series = ubuntu.getSeries(name_or_version=upstream_series_name)
 
         patched_sources = patches_archive.getPublishedSources(

--- a/get-latest-version.py
+++ b/get-latest-version.py
@@ -11,9 +11,10 @@ from launchpadlib.launchpad import Launchpad
 
 DEFAULT_SERIES_NAME = "noble"
 
+PACKAGES_TO_IMPORT_PATH = os.environ.get("PACKAGES_TO_IMPORT_PATH", "/tmp/patched-packages")
 
 def get_packages_list() -> list:
-    with open("/tmp/patched-packages", "r", encoding="utf-8") as file:
+    with open(PACKAGES_TO_IMPORT_PATH, "r", encoding="utf-8") as file:
         items = file.read().splitlines()
     return items
 
@@ -70,6 +71,7 @@ def main():
             upstream_series_name[0] if upstream_series_name else series_name
         )
         print(package_name, upstream_series_name)
+
         
         upstream_series = ubuntu.getSeries(name_or_version=upstream_series_name)
 


### PR DESCRIPTION
This rewrites the Python script that compares packages.
Should work. Proof: https://github.com/stsdc/os-patches/actions/runs/13398951005/job/37424819616
Also PRs created successfully: https://github.com/stsdc/os-patches/pulls

Notable changes:
* Using python script to get list of patched packages from `/tmp/patched-packages`. Previously it was done in shell in the workflow. When we're doing this in python script, we do not have to execute login and connect to the PPA
* Using GitPython library to perform actions on git repository. Previously it was done by executing shell commands in Python script. It wasn't reliable, looks like there were some race conditions and it failed sometimes on first package and sometimes later (but I'm not 100% sure)
* The script is now parsing `apt source <package>` to get real name of directory, where source code is extracted. Previously it was composed from package name and pocket version, however directory name could vary from package to package