### PR TITLE
Make sure not to leave files/directories that removed in upstream

### DIFF
--- a/get-latest-version.py
+++ b/get-latest-version.py
@@ -136,6 +136,17 @@ def main():
                 stderr=subprocess.PIPE,
                 check=True,
             )
+
+            # Remove all files/directories excluding ".", "..", and ".git" before copying upstream source
+            # to prevent files/directories removed in upstream from being leftover
+            subprocess.run(
+                f"ls -a | grep -v -E '^\.$|^\.\.$|^\.git$' | xargs rm -rf",
+                shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+            )
+
             subprocess.run(
                 f"cp -r {extraction_dest}/* .",
                 shell=True,


### PR DESCRIPTION
Currently the `grub2-noble` branch (not the `-patched` one) fails to build with `debuild -us -uc` because the leftovers that no longer exists in the original source are detected as local changes:

```
dpkg-source: info: local changes detected, the modified files are:
 os-patches/grub-core/term/ns8250-spcr.c
 os-patches/include/grub/ieee1275/alloc.h
dpkg-source: error: aborting due to unexpected upstream changes, see /tmp/grub2_2.12-1ubuntu7.1.diff.6Yf8OW
```

This PR removes all files/directories excluding `.`, `..`, and `.git` before copying upstream source to prevent files/directories removed in upstream from being leftover.
