### PR TITLE
upstream-os-release: Update Ubuntu version

### DIFF
--- a/etc/upstream-os-release
+++ b/etc/upstream-os-release
@@ -1,7 +1,7 @@
-PRETTY_NAME="Ubuntu 24.04.1 LTS"
+PRETTY_NAME="Ubuntu 24.04.2 LTS"
 NAME="Ubuntu"
 VERSION_ID="24.04"
-VERSION="24.04.1 LTS (Noble Numbat)"
+VERSION="24.04.2 LTS (Noble Numbat)"
 VERSION_CODENAME=noble
 ID=ubuntu
 ID_LIKE=debian


### PR DESCRIPTION
This fixes the System plug says that latest elementary OS 8.0.1 is built on Ubuntu 24.04.1 LTS.

Please [sync Launchpad source with GitHub](https://code.launchpad.net/~elementary-os/elementaryos/+git/os-patches) and then request build of [base-files-noble](https://code.launchpad.net/~elementary-os/+recipe/base-files-noble) on Launchpad once this PR get merged. I don't have privilege to do this.

## After
![image](https://github.com/user-attachments/assets/d5e01a2a-8f95-4b15-885c-94a12c3442ce)

## Before
![image](https://github.com/user-attachments/assets/a470ff24-8e7c-4aa0-ae34-c41f3a8a2315)

## How to Test

```
git clone https://github.com/elementary/os-patches.git
cd os-patches/
git switch ryonakano/base-files-noble-patched-update-version 
sudo apt install devscripts build-essential 
sudo apt build-dep base-files
debuild -us -uc
sudo apt install -y --allow-downgrades ../base-files_13ubuntu10.2_amd64.deb 
```
