### PR TITLE
get-latest-version: Fix the apt-sourced directory is cleaned up

### DIFF
--- a/get-latest-version.py
+++ b/get-latest-version.py
@@ -113,6 +113,16 @@ def main():
             # Create and checkout the new branch
             current_repo.git.checkout("-b", new_branch)
 
+            # Remove all files/directories excluding ".", "..", and ".git" before copying upstream source
+            # to prevent files/directories removed in upstream from being leftover
+            subprocess.run(
+                f"ls -a | grep -v -E '^\.$|^\.\.$|^\.git$' | xargs rm -rf",
+                shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+            )
+
             p_apt_source = subprocess.run(
                 f"apt source {package_name}",
                 shell=True,
@@ -131,16 +141,6 @@ def main():
 
             subprocess.run(
                 "rm *.tar.* *.dsc",
-                shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=True,
-            )
-
-            # Remove all files/directories excluding ".", "..", and ".git" before copying upstream source
-            # to prevent files/directories removed in upstream from being leftover
-            subprocess.run(
-                f"ls -a | grep -v -E '^\.$|^\.\.$|^\.git$' | xargs rm -rf",
                 shell=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,


### PR DESCRIPTION
Regression of #314

This fixes the Actions is failing these days with the following error:

```
Traceback (most recent call last):
base-files noble
dpkg-source: info: extracting base-files in base-files-13ubuntu10.3
  File "/__w/os-patches/os-patches/get-latest-version.py", line 179, in <module>
  File "/__w/os-patches/os-patches/get-latest-version.py", line 150, in main
  File "/usr/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'cp -r base-files-13ubuntu10.3/. .' returned non-zero exit status 1.
Error: Process completed with exit code 1.
```

This is because we clean up the working directory **after** retrieving the source code with `apt source`, which means the retrieved source is wiped out and thus `cp -r` fails. This PR makes sure we clean up the working directory **before** `apt source`.

---

Another solution would be to use a different temporary folder for `apt source`.
