### PR TITLE
Rename the default branch to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The packages are included into the [OS Patches Repository](https://launchpad.net
 
 ## How is this repository working
 
-The `master` branch is composed of GitHub Workflows that are running daily to
+The `main` branch is composed of GitHub Workflows that are running daily to
 check for any new version in the Ubuntu repositories of the patched components.
 If a newer version of a package is found in the Ubuntu repositories, a Pull Request
 will be opened in this repository to let the team know to rebase patches and push

--- a/get-latest-version.py
+++ b/get-latest-version.py
@@ -172,7 +172,7 @@ def main():
                 title=pull_title,
                 body=f"""A new version of `{package_name} {pocket_version}` replaces `{patched_version}`.""",
             )
-            current_repo.git.checkout("master")
+            current_repo.git.checkout("main")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I'll rename the default branch name to main from the Settings page in this repository after this PR get merged.
