### PR TITLE
packages: Use fixed Docker image tag

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -8,10 +8,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ubuntu-codename: ['bionic', 'focal', 'jammy', 'noble', 'resolute']
+        include:
+          - ubuntu-codename: 'bionic'
+            elementary-codename: 'juno'
+          - ubuntu-codename: 'focal'
+            elementary-codename: 'odin'
+          - ubuntu-codename: 'jammy'
+            elementary-codename: 'horus'
+          - ubuntu-codename: 'noble'
+            elementary-codename: 'circe'
+          - ubuntu-codename: 'resolute'
+            elementary-codename: 'tanit'
 
     container:
-      image: ghcr.io/elementary/docker:stable
+      image: ghcr.io/elementary/docker:${{ matrix.elementary-codename }}-stable
 
     env:
       PACKAGES_TO_IMPORT_PATH: '/tmp/patched-packages'


### PR DESCRIPTION
`ghcr.io/elementary/docker:stable` points to `ghcr.io/elementary/docker:circe-stable` at the moment, which means the workflow will suggest updates available for Noble towards all versions of elementary OS unintentionally: see https://github.com/elementary/os-patches/pull/349 for example. This PR fixes this problem by using fixed tag name for each Ubuntu codename.
