### PR TITLE
get-latest-version: Use launchpadlib and dpkg-source instead of apt source

### DIFF
--- a/get-latest-version.py
+++ b/get-latest-version.py
@@ -136,8 +136,6 @@ def main():
             for idx, source_url in enumerate(source_urls):
                 source_content = requests.get(source_url).content
                 source_file = source_files[idx]
-                source_content = requests.get(source_urls[i]).content
-                source_file = source_files[i]
 
                 with open(source_file, "wb") as f:
                     f.write(source_content)

--- a/get-latest-version.py
+++ b/get-latest-version.py
@@ -129,7 +129,9 @@ def main():
             source_urls = upstream_sources[0].sourceFileUrls()
             source_files = ["/tmp/" + os.path.basename(url) for url in source_urls]
             dsc_file = [file for file in source_files if re.search(r".*\.dsc$", file)][0]
-            for i in range(len(source_urls)):
+            for idx, source_url in enumerate(source_urls):
+                source_content = requests.get(source_url).content
+                source_file = source_files[idx]
                 source_content = requests.get(source_urls[i]).content
                 source_file = source_files[i]
 

--- a/get-latest-version.py
+++ b/get-latest-version.py
@@ -4,6 +4,9 @@ import os
 import subprocess
 import sys
 import apt_pkg
+import re
+import requests
+import tempfile
 import git
 import git.config
 from github import Github
@@ -123,29 +126,28 @@ def main():
                 check=True,
             )
 
-            p_apt_source = subprocess.run(
-                f"apt source {package_name}",
-                shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=True,
-                encoding="utf-8",
-            )
+            source_urls = upstream_sources[0].sourceFileUrls()
+            source_files = ["/tmp/" + os.path.basename(url) for url in source_urls]
+            dsc_file = [file for file in source_files if re.search(r".*\.dsc$", file)][0]
+            for i in range(len(source_urls)):
+                source_content = requests.get(source_urls[i]).content
+                source_file = source_files[i]
 
-            # getting the directory to which the source is extracted
-            extraction_dest = ""
-            for line in p_apt_source.stdout.split("\n"):
-                if "dpkg-source: info: extracting" in line:
-                    print(line)
-                    extraction_dest = line.split()[-1]
+                with open(source_file, "wb") as f:
+                    f.write(source_content)
+
+            extraction_dest = "/tmp/extract_dir"
 
             subprocess.run(
-                "rm *.tar.* *.dsc",
+                f"dpkg-source -x {dsc_file} {extraction_dest}",
                 shell=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 check=True,
             )
+
+            for file in source_files:
+                os.remove(file)
 
             subprocess.run(
                 f"cp -r {extraction_dest}/. .",

--- a/get-latest-version.py
+++ b/get-latest-version.py
@@ -6,7 +6,6 @@ import sys
 import apt_pkg
 import re
 import requests
-import tempfile
 import git
 import git.config
 from github import Github


### PR DESCRIPTION
The current solution with `apt source` can only pull source code for the upstream series that this script runs, which means a backported package can overwritten with an older version of it like https://github.com/elementary/os-patches/pull/349. This PR fixes that problem by manually downloading source code from the URL launchpadlib knows and extracts using `dpkg-source`.

Works confirmed in my forked repository:
https://github.com/ryonakano/os-patches/pull/2

c.f. the invalid PR against this repository:
https://github.com/elementary/os-patches/pull/354

FYI API reference of launchpadlib: https://launchpad.net/+apidoc/1.0.html
