### PR TITLE
packages: Allow manual run

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -2,6 +2,7 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Allows manual run of package updates. This is useful when debugging in your forked repository.
