### PR TITLE
get-latest-version: Set git config only when env value is set

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -40,6 +40,8 @@ jobs:
 
     - name: Verify that we are shipping the latest version
       env:
+        GIT_USER_EMAIL: github-actions[bot]@users.noreply.github.com
+        GIT_USER_NAME: github-actions[bot]
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_REPOSITORY: ${{ github.event.repository.name }}
       run: python3 get-latest-version.py "${{ matrix.ubuntu-codename }}"

--- a/get-latest-version.py
+++ b/get-latest-version.py
@@ -34,10 +34,14 @@ def main():
     # Configuring this repo to be able to commit as a bot
     current_repo = git.Repo(".")
     with current_repo.config_writer(config_level="global") as git_config:
-        git_config.set_value(
-            "user", "email", "github-actions[bot]@users.noreply.github.com"
-        )
-        git_config.set_value("user", "name", "github-actions[bot]")
+        git_user_email = os.environ.get("GIT_USER_EMAIL")
+        if git_user_email:
+            git_config.set_value("user", "email", git_user_email)
+
+        git_user_name = os.environ.get("GIT_USER_NAME")
+        if git_user_name:
+            git_config.set_value("user", "name", git_user_name)
+
         git_config.set_value("checkout", "defaultRemote", "origin")
         git_config.add_value("safe", "directory", "/__w/os-patches/os-patches")
 

--- a/get-latest-version.py
+++ b/get-latest-version.py
@@ -42,6 +42,10 @@ def main():
         if git_user_name:
             git_config.set_value("user", "name", git_user_name)
 
+        github_workspace = os.environ.get("GITHUB_WORKSPACE")
+        if github_workspace:
+            git_config.add_value("safe", "directory", github_workspace)
+
     current_repo.git.fetch("--all")
 
     github_token = os.environ["GITHUB_TOKEN"]

--- a/get-latest-version.py
+++ b/get-latest-version.py
@@ -42,9 +42,6 @@ def main():
         if git_user_name:
             git_config.set_value("user", "name", git_user_name)
 
-        git_config.set_value("checkout", "defaultRemote", "origin")
-        git_config.add_value("safe", "directory", "/__w/os-patches/os-patches")
-
     current_repo.git.fetch("--all")
 
     github_token = os.environ["GITHUB_TOKEN"]


### PR DESCRIPTION
Preparation to make this Python script can be run locally; only set git config if a designated environment variable is set, making the script not to pollute your .gitconfig when running locally.

Setting `checkout.defaultRemote` does nothing since `origin` is the unique remote whether running locally or running on GitHub Actions so I removed while I'm here.
